### PR TITLE
Exit with FALSE handling 'help' argument.

### DIFF
--- a/src/shflags
+++ b/src/shflags
@@ -825,7 +825,7 @@ _flags_parseGetopt()
       if [ ${FLAGS_help} -eq ${FLAGS_TRUE} ]; then
         flags_help
         flags_error='help requested'
-        flags_return=${FLAGS_TRUE}
+        flags_return=${FLAGS_FALSE}
         break
       fi
     fi


### PR DESCRIPTION
'help' argument is a special case arg intended just to print help message and
exit the script. Therefore, you have to return FLAGS_FALSE and propagate this
to the user to give a chance to stop the script.

Typicall usage of shflags is like below

   FLAGS "$@" || exit $?

and it should do the job to exit script on '--help' as expected.

Signed-off-by: Waldemar Rymarkiewicz <waldemar.rymarkiewicz@gmail.com>