### PR TITLE
Allow behavior of '--help' flag evaluation being treated as an error to be overridden

### DIFF
--- a/shflags
+++ b/shflags
@@ -880,8 +880,10 @@ _flags_parseGetopt() {
       # shellcheck disable=SC2154
       if [ "${FLAGS_help}" -eq ${FLAGS_TRUE} ]; then
       	flags_help
-	if [ $? -eq ${FLAGS_FALSE} ]; then
+	if [ $? -eq ${FLAGS_TRUE} ]; then
+	  flags_error='help requested'
 	  flags_return = ${FLAGS_FALSE}
+	  break
 	fi
       fi
     fi
@@ -1166,7 +1168,10 @@ flags_help() {
     done
   fi
 
-  return ${FLAGS_FALSE}
+  unset flags_boolStr_ flags_default_ flags_defaultStr_ flags_emptyStr_ \
+      flags_flagStr_ flags_help_ flags_helpStr flags_helpStrLen flags_name_ \
+      flags_columns_ flags_short_ flags_type_ flags_usName_
+  return ${FLAGS_TRUE}
 }
 
 # Reset shflags back to an uninitialized state.

--- a/shflags
+++ b/shflags
@@ -879,12 +879,12 @@ _flags_parseGetopt() {
     if [ "${_flags_usName_}" = 'help' ]; then
       # shellcheck disable=SC2154
       if [ "${FLAGS_help}" -eq ${FLAGS_TRUE} ]; then
-      	flags_help
-	if [ $? -eq ${FLAGS_TRUE} ]; then
-	  flags_error='help requested'
-	  flags_return = ${FLAGS_FALSE}
-	  break
-	fi
+        flags_help
+        if [ $? -eq ${FLAGS_TRUE} ]; then
+          flags_error='help requested'
+          flags_return = ${FLAGS_FALSE}
+          break
+        fi
       fi
     fi
 

--- a/shflags
+++ b/shflags
@@ -879,10 +879,8 @@ _flags_parseGetopt() {
     if [ "${_flags_usName_}" = 'help' ]; then
       # shellcheck disable=SC2154
       if [ "${FLAGS_help}" -eq ${FLAGS_TRUE} ]; then
-        flags_help
-        flags_error='help requested'
-        flags_return=${FLAGS_FALSE}
-        break
+      	flags_help
+        flags_return=$?
       fi
     fi
 
@@ -1166,10 +1164,7 @@ flags_help() {
     done
   fi
 
-  unset flags_boolStr_ flags_default_ flags_defaultStr_ flags_emptyStr_ \
-      flags_flagStr_ flags_help_ flags_helpStr flags_helpStrLen flags_name_ \
-      flags_columns_ flags_short_ flags_type_ flags_usName_
-  return ${FLAGS_TRUE}
+  return ${FLAGS_FALSE}
 }
 
 # Reset shflags back to an uninitialized state.

--- a/shflags
+++ b/shflags
@@ -882,7 +882,7 @@ _flags_parseGetopt() {
         flags_help
         if [ $? -eq ${FLAGS_TRUE} ]; then
           flags_error='help requested'
-          flags_return = ${FLAGS_FALSE}
+          flags_return=${FLAGS_FALSE}
           break
         fi
       fi

--- a/shflags
+++ b/shflags
@@ -880,7 +880,9 @@ _flags_parseGetopt() {
       # shellcheck disable=SC2154
       if [ "${FLAGS_help}" -eq ${FLAGS_TRUE} ]; then
       	flags_help
-        flags_return=$?
+	if [ $? -eq ${FLAGS_FALSE} ]; then
+	  flags_return = ${FLAGS_FALSE}
+	fi
       fi
     fi
 


### PR DESCRIPTION
Introduces a check to only execute `break` from evaluation loop if `flags_help` returns true. That way, `flags_help` can be overridden to return false if one wants usage of the `--help` flag to not result in an error.
This should resolve issue #54.